### PR TITLE
Use mimalloc and update release profiles for Rust benchmarks

### DIFF
--- a/benches/moka-rs/Cargo.toml
+++ b/benches/moka-rs/Cargo.toml
@@ -10,8 +10,12 @@ sync = ["moka"]
 async = ["moka/future", "tokio/full"]
 
 [dependencies]
+mimalloc = { version = "0.1.26", default-features = false }
 moka = {version = "0.6.1", optional = true }
 serde = {version = "1", features = ["serde_derive"] }
 serde_json = "1.0.68"
 tokio = {version = "1.12.0", optional = true }
 
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/benches/moka-rs/src/main.rs
+++ b/benches/moka-rs/src/main.rs
@@ -3,6 +3,8 @@ extern crate serde;
 
 use std::path::Path;
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Serialize, Deserialize)]
 struct Dataset {
@@ -20,9 +22,9 @@ struct KV {
 
 #[cfg(feature = "sync")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use moka::sync::Cache;
     use std::fs;
     use std::time::Instant;
-    use moka::sync::Cache;
 
     let content = fs::read(Path::new("mock.json"))?;
     let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
@@ -44,9 +46,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(not(feature = "sync"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use moka::future::Cache;
     use std::fs;
     use std::time::Instant;
-    use moka::future::Cache;
 
     let content = fs::read(Path::new("mock.json"))?;
     let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
@@ -64,3 +66,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+

--- a/benches/ristretto-rs/Cargo.toml
+++ b/benches/ristretto-rs/Cargo.toml
@@ -10,7 +10,12 @@ sync = ["stretto/sync"]
 async = ["stretto/async", "tokio/full"]
 
 [dependencies]
+mimalloc = { version = "0.1.26", default-features = false }
 stretto = { path = "../..", optional = true }
 serde = {version = "1", features = ["serde_derive"] }
 serde_json = "1.0.68"
 tokio = {version = "1.12.0", optional = true}
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/benches/ristretto-rs/src/main.rs
+++ b/benches/ristretto-rs/src/main.rs
@@ -4,6 +4,9 @@ extern crate serde;
 use std::path::Path;
 use stretto::{Cache, KeyBuilder};
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Serialize, Deserialize)]
 struct Dataset {
     data: Vec<KV>,
@@ -99,4 +102,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-


### PR DESCRIPTION
As mentioned in a Reddit comment 😃 

This improves benchmarks considerably on my machine:

```
---Go Ristretto Finished in 16ms---
hit: 98858 miss: 25754 keys-added: 6657 keys-updated: 12865 keys-evicted: 5598 cost-added: 6234984 cost-evicted:
 5235204 sets-dropped: 0 sets-rejected: 6231 gets-dropped: 21504 gets-kept: 102976 gets-total: 124612 hit-ratio:
 0.79
---Sync Stretto Finished in 9ms---
Metrics::Op {
  "hit": 96501,
  "miss": 28111,
  "keys-added": 25447,
  "keys-updated": 2653,
  "keys-evicted": 24420,
  "cost-added": 24838984,
  "cost-evicted": 23839632,
  "sets-dropped": 0,
  "sets-rejected": 0,
  "gets-dropped": 0,
  "gets-kept": 0,
  "gets-total": 124612,
  "hit-ratio": 0.77
}
---Async Stretto Finished in 11ms---
Metrics::Op {
  "hit": 97583,
  "miss": 27029,
  "keys-added": 25630,
  "keys-updated": 1389,
  "keys-evicted": 24600,
  "cost-added": 24983368,
  "cost-evicted": 23983788,
  "sets-dropped": 0,
  "sets-rejected": 0,
  "gets-dropped": 0,
  "gets-kept": 0,
  "gets-total": 124612,
  "hit-ratio": 0.78
}
---Sync Moka Finished in 17ms---
---Async Moka Finished in 18ms---
```