### PR TITLE
Update moka-rs/main in bench

### DIFF
--- a/benches/bench.sh
+++ b/benches/bench.sh
@@ -2,6 +2,7 @@
 
 set -ue
 
+rm -rf bin
 mkdir -p bin
 
 cd mock

--- a/benches/moka-rs/src/main.rs
+++ b/benches/moka-rs/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate serde;
 
-use std::path::Path;
+use std::{fmt, hash::{BuildHasher, Hasher}, path::Path};
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -20,25 +20,92 @@ struct KV {
     cost: i64,
 }
 
+#[derive(Default)]
+struct DumbHasher(u64);
+
+impl Hasher for DumbHasher {
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        unimplemented!()
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Default)]
+struct DumbBuildHasher;
+
+impl BuildHasher for DumbBuildHasher {
+    type Hasher = DumbHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        DumbHasher::default()
+    }
+}
+
+#[derive(Default)]
+struct OpMetrics {
+    hit: u64,
+    miss: u64,
+    gets_total: u64,
+}
+
+impl OpMetrics {
+    fn hit_ratio(&self) -> f64 {
+        if self.gets_total == 0 {
+            0.0
+        } else {
+            let gt = self.gets_total as f64;
+            self.hit as f64 / gt
+        }
+    }
+}
+
+impl fmt::Debug for OpMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hit_ratio = (self.hit_ratio() * 100.0).round() / 100.0;
+        f.debug_struct("OpMetrics")
+            .field("hit", &self.hit)
+            .field("miss", &self.miss)
+            .field("gets_total", &self.gets_total)
+            .field("hit_ratio", &hit_ratio)
+            .finish()
+    }
+}
+
 #[cfg(feature = "sync")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use moka::sync::Cache;
+    use moka::sync::CacheBuilder;
     use std::fs;
     use std::time::Instant;
 
     let content = fs::read(Path::new("mock.json"))?;
-    let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
+    let mut dataset: Dataset = serde_json::from_slice(content.as_slice())?;
+    recalc_hash(&mut dataset);
+    let dataset = dataset;
 
-    let c = Cache::new(12960);
+    let mut metrics = OpMetrics::default();
+
+    let c = CacheBuilder::new(12960).build_with_hasher(DumbBuildHasher::default());
     let time = Instant::now();
 
     for kv in dataset.data {
-        if let None = c.get(&kv.key) {
-            c.insert(kv.key, kv.val);
+        metrics.gets_total += 1;
+        if c.get(&kv.hash).is_none() {
+            c.insert(kv.hash, kv.val);
+            metrics.miss += 1;
+        } else {
+            metrics.hit += 1;
         }
     }
     let elapsed = time.elapsed();
     println!("---Sync Moka Finished in {}ms---", elapsed.as_millis());
+    println!("{:?}", metrics);
 
     Ok(())
 }
@@ -46,24 +113,44 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(not(feature = "sync"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use moka::future::Cache;
+    use moka::future::CacheBuilder;
     use std::fs;
     use std::time::Instant;
 
     let content = fs::read(Path::new("mock.json"))?;
-    let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
+    let mut dataset: Dataset = serde_json::from_slice(content.as_slice())?;
+    recalc_hash(&mut dataset);
+    let dataset = dataset;
 
-    let c = Cache::new(12960);
+    let mut metrics = OpMetrics::default();
+
+    let c = CacheBuilder::new(12960).build_with_hasher(DumbBuildHasher::default());
     let time = Instant::now();
 
     for kv in dataset.data {
-        if let None = c.get(&kv.key) {
-            c.insert(kv.key, kv.val).await;
+        metrics.gets_total += 1;
+        if c.get(&kv.hash).is_none() {
+            c.insert(kv.hash, kv.val).await;
+            metrics.miss += 1;
+        } else {
+            metrics.hit += 1;
         }
     }
     let elapsed = time.elapsed();
     println!("---Async Moka Finished in {}ms---", elapsed.as_millis());
+    println!("{:?}", metrics);
 
     Ok(())
 }
 
+fn recalc_hash(dataset: &mut Dataset) {
+    use std::hash::Hash;
+    let build_hasher = std::collections::hash_map::RandomState::default();
+    for kv in &mut dataset.data {
+        let key = &kv.key;
+        let mut hasher = build_hasher.build_hasher();
+        key.hash(&mut hasher);
+        kv.hash = hasher.finish();
+        kv.conflict = 0;
+    }
+}

--- a/benches/ristretto-rs/src/main.rs
+++ b/benches/ristretto-rs/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let content = fs::read(Path::new("mock.json"))?;
     let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
 
-    let c = Cache::builder(12960, 1e6 as i64, KH::default())
+    let c = Cache::builder(12960, 1e6 as i64)
         .set_metrics(true)
         .finalize()
         .unwrap();
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             hash: kv.hash,
             conflict: kv.conflict,
         };
-        if let None = c.get(&kc) {
+        if c.get(&kc).is_none() {
             c.insert(kc, kv.val, kv.cost);
         }
     }
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let content = fs::read(Path::new("mock.json")).await?;
     let dataset: Dataset = serde_json::from_slice(content.as_slice())?;
 
-    let c = AsyncCache::builder(12960, 1e6 as i64, KH::default())
+    let c = AsyncCache::builder(12960, 1e6 as i64)
         .set_metrics(true)
         .finalize()
         .unwrap();
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             hash: kv.hash,
             conflict: kv.conflict,
         };
-        if let None = c.get(&kc) {
+        if c.get(&kc).is_none() {
             c.insert(kc, kv.val, kv.cost).await;
         }
     }


### PR DESCRIPTION
Hi. I just found Stretto. Very nice!

This PR updates the stuff in the `bench` directory:

1. Fix compile errors in `bench/ristretto-rs/src/main.rs`.
2. Update `bench/moka-rs/src/main.rs`:
   - Show some statistics (hit, miss, gets total and hit ratio) at the end of run.
   - Like Stretto and Ristretto, use precalculated hashes for keys, instead of calculating them at `get` and `insert` times.
3. Ensure to clear `bench/bin` before building binaries and copying them into there. I found overriding binaries there somehow made them corrupted on my Mac. (Maybe due to an anti-virus software?)

Just FYI, here is a benchmark result from my Mac:

**Disclaimer**

- I am the Moka author.
- This is an apples-vs-oranges comparison as Moka v0.6.1 does not support cost-based eviction while others do.

**Result**

```console
# macOS Big Sur (arm64), Apple M1 chip
# Rust 1.57.0 stable

$ ./bench.sh
...

Generating mock data...
---Go Ristretto Finished in 16ms---
hit: 98690 miss: 24431 keys-added: 6763 keys-updated: 11565 keys-evicted: 5705 cost-added: 6243336 cost-evicted: 5243616 sets-dropped: 0 sets-rejected: 6103 gets-dropped: 21760 gets-kept: 101248 gets-total: 123121 hit-ratio: 0.80
---Sync Stretto Finished in 18ms---
Metrics::Op {
  "hit": 96257,
  "miss": 26864,
  "keys-added": 26593,
  "keys-updated": 262,
  "keys-evicted": 25571,
  "cost-added": 25817500,
  "cost-evicted": 24817532,
  "sets-dropped": 0,
  "sets-rejected": 0,
  "gets-dropped": 0,
  "gets-kept": 0,
  "gets-total": 123121,
  "hit-ratio": 0.78
}
---Async Stretto Finished in 20ms---
Metrics::Op {
  "hit": 96758,
  "miss": 26363,
  "keys-added": 25897,
  "keys-updated": 461,
  "keys-evicted": 24863,
  "cost-added": 25120192,
  "cost-evicted": 24120308,
  "sets-dropped": 0,
  "sets-rejected": 0,
  "gets-dropped": 0,
  "gets-kept": 0,
  "gets-total": 123121,
  "hit-ratio": 0.79
}
---Sync Moka Finished in 19ms---
OpMetrics { hit: 121825, miss: 1296, gets_total: 123121, hit_ratio: 0.99 }
---Async Moka Finished in 19ms---
OpMetrics { hit: 121825, miss: 1296, gets_total: 123121, hit_ratio: 0.99 }
```

**Some thoughts:**

- Moka's hit ratio is somewhat higher than others (0.99 vs 0.79, 0.80).
    - This might be caused by the difference in cache admission policies:
        - Stretto and Ristretto use a write buffer and while entries are in the buffer, `get` will not return them. (cache miss)
        - Moka uses a write buffer too but while entries are in the buffer, `get` will return them. (cache hit)
    - You might want to adjust the key distribution in the dataset to reduce the hit ratio in Moka.
