### PR TITLE
feat: add non-panicking alternatives for cache methods that mutably borrow buckets

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum CacheError {
 
     /// Error when receive msg between threads.
     RecvError(String),
+
+    /// Error when updating entries
+    UpdateError(String),
 }
 
 impl CacheError {
@@ -44,6 +47,7 @@ impl CacheError {
             CacheError::InvalidNumCounters => write!(f, "num_counters can't be zero"),
             CacheError::InvalidMaxCost => write!(f, "max_cost can't be zero"),
             CacheError::InvalidBufferSize => write!(f, "buffer_size can't be zero"),
+            CacheError::UpdateError(msg) => write!(f, "update error: {} ", msg),
         }
     }
 }


### PR DESCRIPTION
As the `.borrow_mut()` method on the `RwLock` used for the expiration map buckets
can panic when called and already borrowed, this change adds non-panicking
alternatives to the caches' `update` and `insert*` methods prefixed by `try_`
to make it possible for library users to handle the error.

Related to #10 