### PR TITLE
Use owned variables in examples

### DIFF
--- a/examples/async_example.rs
+++ b/examples/async_example.rs
@@ -3,21 +3,30 @@ use stretto::AsyncCache;
 
 #[tokio::main]
 async fn main() {
-    let c: AsyncCache<&str, &str> = AsyncCache::new(12960, 1e6 as i64, tokio::spawn).unwrap();
+    // cache is intended to take ownership of key and value
+    let c: AsyncCache<String, String> = AsyncCache::new(12960, 1e6 as i64, tokio::spawn).unwrap();
 
     // set a value with a cost of 1
-    c.insert("a", "a", 1).await;
+    c.insert("key1".to_string(), "value1".to_string(), 1).await;
 
     // set a value with a cost of 1 and ttl
-    c.insert_with_ttl("b", "b", 1, Duration::from_secs(3)).await;
+    c.insert_with_ttl(
+        "key2".to_string(),
+        "value2".to_string(),
+        1,
+        Duration::from_secs(3),
+    )
+    .await;
 
     // wait for value to pass through buffers
     c.wait().await.unwrap();
 
+    // Create a search key
+    let key1 = "key1".to_string();
     // when we get the value, we will get a ValueRef, which contains a RwLockReadGuard
     // so when we finish use this value, we must release the ValueRef
-    let v = c.get(&"a").await.unwrap();
-    assert_eq!(v.value(), &"a");
+    let v = c.get(&key1).await.unwrap();
+    assert_eq!(v.value(), &"value1");
     // release the value
     v.release(); // or drop(v)
 
@@ -25,19 +34,18 @@ async fn main() {
     {
         // when we get the value, we will get a ValueRef, which contains a RwLockWriteGuard
         // so when we finish use this value, we must release the ValueRefMut
-        let mut v = c.get_mut(&"a").await.unwrap();
-        v.write("aa");
-        assert_eq!(v.value(), &"aa");
+        let mut v = c.get_mut(&key1).await.unwrap();
+        v.write("value2".to_string());
+        assert_eq!(v.value(), &"value2");
         // release the value
     }
 
     // if you just want to do one operation
-    let v = c.get_mut(&"a").await.unwrap();
-    v.write_once("aaa");
+    let v = c.get_mut(&key1).await.unwrap();
+    v.write_once("value3".to_string());
 
-    let v = c.get(&"a").await.unwrap();
-    println!("{}", v);
-    assert_eq!(v.value(), &"aaa");
+    let v = c.get(&key1).await.unwrap();
+    assert_eq!(v.value(), &"value3");
     v.release();
 
     // clear the cache
@@ -45,5 +53,5 @@ async fn main() {
     // wait all the operations are finished
     c.wait().await.unwrap();
 
-    assert!(c.get(&"a").await.is_none());
+    assert!(c.get(&key1).await.is_none());
 }

--- a/examples/sync_example.rs
+++ b/examples/sync_example.rs
@@ -2,43 +2,51 @@ use std::time::Duration;
 use stretto::Cache;
 
 fn main() {
+    // cache is intended to take ownership of key and value
     let c = Cache::new(12960, 1e6 as i64).unwrap();
 
     // set a value with a cost of 1
-    c.insert("a", "a", 1);
+    c.insert("key1".to_string(), "value1".to_string(), 1);
     // set a value with a cost of 1 and ttl
-    c.insert_with_ttl("b", "b", 1, Duration::from_secs(3));
+    c.insert_with_ttl(
+        "key2".to_string(),
+        "value2".to_string(),
+        1,
+        Duration::from_secs(3),
+    );
 
     // wait for value to pass through buffers
     c.wait().unwrap();
 
+    // Create a search key
+    let key1 = "key1".to_string();
     // when we get the value, we will get a ValueRef, which contains a RwLockReadGuard
     // so when we finish use this value, we must release the ValueRef
-    let v = c.get(&"a").unwrap();
-    assert_eq!(v.value(), &"a");
+    let v = c.get(&key1).unwrap();
+    assert_eq!(v.value(), &"value1");
     v.release();
 
     // lock will be auto released when out of scope
     {
         // when we get the value, we will get a ValueRef, which contains a RwLockWriteGuard
         // so when we finish use this value, we must release the ValueRefMut
-        let mut v = c.get_mut(&"a").unwrap();
-        v.write("aa");
-        assert_eq!(v.value(), &"aa");
+        let mut v = c.get_mut(&key1).unwrap();
+        v.write("value3".to_string());
+        assert_eq!(v.value(), &"value3");
         // release the value
     }
 
     // if you just want to do one operation
-    let v = c.get_mut(&"a").unwrap();
-    v.write_once("aaa");
+    let v = c.get_mut(&key1).unwrap();
+    v.write_once("value4".to_string());
 
-    let v = c.get(&"a").unwrap();
-    assert_eq!(v.value(), &"aaa");
+    let v = c.get(&key1).unwrap();
+    assert_eq!(v.value(), &"value4");
     v.release();
 
     // clear the cache
     c.clear().unwrap();
     // wait all the operations are finished
     c.wait().unwrap();
-    assert!(c.get(&"a").is_none());
+    assert!(c.get(&key1).is_none());
 }


### PR DESCRIPTION
The cache examples now own the data, and not static references, as mentioned in https://github.com/al8n/stretto/issues/48. Also variable names are modified to explain their usage.